### PR TITLE
Fix children type for React 18

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ export const Disable: React.FC<{
   disabledProps?: any;
   disabledStyles?: React.CSSProperties;
   disabledOpacity?: number;
+  children: React.ReactNode;
 }> = ({
   as = 'div',
   children,


### PR DESCRIPTION
Related React 18 issue https://stackoverflow.com/a/71948814

Without the fix, I get this error: 
<img width="942" alt="CleanShot 2022-11-08 at 10 15 49@2x" src="https://user-images.githubusercontent.com/715405/200538285-9a5d4272-4f5c-4cd9-913e-00eb093e982a.png">
